### PR TITLE
ci: use token to install libextism

### DIFF
--- a/.github/actions/libextism/action.yml
+++ b/.github/actions/libextism/action.yml
@@ -12,4 +12,4 @@ runs:
     - uses: ./.extism-cli/.github/actions/extism-cli
     - name: Install
       shell: bash
-      run: sudo extism lib install --version git
+      run: sudo extism lib install --version git --github-token abcdef

--- a/.github/actions/libextism/action.yml
+++ b/.github/actions/libextism/action.yml
@@ -2,6 +2,11 @@ on: [workflow_call]
 
 name: libextism
 
+inputs:
+  gh-token:
+    description: "A GitHub PAT"
+    default: ${{ github.token }}
+
 runs:
   using: composite
   steps:
@@ -12,4 +17,4 @@ runs:
     - uses: ./.extism-cli/.github/actions/extism-cli
     - name: Install
       shell: bash
-      run: sudo extism lib install --version git --github-token abcdef
+      run: sudo extism lib install --version git --github-token ${{ inputs.gh-token }}


### PR DESCRIPTION
This method is superior to the other methods of passing the token to the workflow as it doesn't require explicitly passing the token.

https://szabo.jp/2023/06/18/accessing-the-github-token-from-an-action/