### PR TITLE
feat: add CompiledPlugin and call_with_host_context

### DIFF
--- a/src/Extism/Bindings.hs
+++ b/src/Extism/Bindings.hs
@@ -24,6 +24,8 @@ newtype ExtismCancelHandle = ExtismCancelHandle () deriving (Show)
 
 newtype ExtismCurrentPlugin = ExtismCurrentPlugin () deriving (Show)
 
+newtype ExtismCompiledPlugin = ExtismCompiledPlugin () deriving (Show)
+
 -- | Low-level Wasm types
 data ValType = I32 | I64 | F32 | F64 | V128 | FuncRef | ExternRef deriving (Show, Eq)
 
@@ -94,6 +96,14 @@ foreign import ccall safe "extism.h extism_plugin_new"
   extism_plugin_new ::
     Ptr Word8 -> Word64 -> Ptr (Ptr ExtismFunction) -> Word64 -> CBool -> Ptr CString -> IO (Ptr ExtismPlugin)
 
+foreign import ccall safe "extism.h extism_plugin_new_from_compiled"
+  extism_plugin_new_from_compiled ::
+    Ptr ExtismCompiledPlugin -> Ptr CString -> IO (Ptr ExtismPlugin)
+
+foreign import ccall safe "extism.h extism_compiled_plugin_new"
+  extism_compiled_plugin_new ::
+    Ptr Word8 -> Word64 -> Ptr (Ptr ExtismFunction) -> Word64 -> CBool -> Ptr CString -> IO (Ptr ExtismCompiledPlugin)
+
 foreign import ccall safe "extism.h extism_plugin_call"
   extism_plugin_call ::
     Ptr ExtismPlugin -> CString -> Ptr Word8 -> Word64 -> IO Int32
@@ -125,6 +135,10 @@ foreign import ccall safe "extism.h extism_plugin_config"
 foreign import ccall safe "extism.h extism_plugin_free"
   extism_plugin_free ::
     Ptr ExtismPlugin -> IO ()
+
+foreign import ccall safe "extism.h extism_compiled_plugin_free"
+  extism_compiled_plugin_free ::
+    Ptr ExtismCompiledPlugin -> IO ()
 
 foreign import ccall safe "extism.h extism_plugin_reset"
   extism_plugin_reset ::

--- a/src/Extism/Bindings.hs
+++ b/src/Extism/Bindings.hs
@@ -108,6 +108,10 @@ foreign import ccall safe "extism.h extism_plugin_call"
   extism_plugin_call ::
     Ptr ExtismPlugin -> CString -> Ptr Word8 -> Word64 -> IO Int32
 
+foreign import ccall safe "extism.h extism_plugin_call_with_host_context"
+  extism_plugin_call_with_host_context ::
+    Ptr ExtismPlugin -> CString -> Ptr Word8 -> Word64 -> Ptr () -> IO Int32
+
 foreign import ccall safe "extism.h extism_plugin_function_exists"
   extism_plugin_function_exists ::
     Ptr ExtismPlugin -> CString -> IO CBool
@@ -179,6 +183,10 @@ foreign import ccall safe "extism.h extism_function_set_namespace"
 foreign import ccall safe "extism.h extism_current_plugin_memory"
   extism_current_plugin_memory ::
     Ptr ExtismCurrentPlugin -> IO (Ptr Word8)
+
+foreign import ccall safe "extism.h extism_current_plugin_host_context"
+  extism_current_plugin_host_context ::
+    Ptr ExtismCurrentPlugin -> IO (Ptr ())
 
 foreign import ccall safe "extism.h extism_current_plugin_memory_alloc"
   extism_current_plugin_memory_alloc ::

--- a/src/Extism/HostFunction.hs
+++ b/src/Extism/HostFunction.hs
@@ -35,6 +35,7 @@ module Extism.HostFunction
     output,
     getParams,
     setResults,
+    hostContext,
     ptr,
   )
 where
@@ -198,6 +199,15 @@ input plugin index =
 input' :: (FromBytes a) => CurrentPlugin -> Int -> IO a
 input' plugin index =
   unwrap <$> input plugin index
+
+hostContext :: CurrentPlugin -> IO (Maybe a)
+hostContext (CurrentPlugin cp _ _ _) = do
+  ptr <- extism_current_plugin_host_context cp
+  if ptr == nullPtr
+    then return Nothing
+    else do
+      x <- deRefStablePtr (castPtrToStablePtr ptr)
+      return $ Just x
 
 callback :: (CurrentPlugin -> a -> IO ()) -> (Ptr ExtismCurrentPlugin -> Ptr Val -> Word64 -> Ptr Val -> Word64 -> Ptr () -> IO ())
 callback f plugin params nparams results nresults ptr = do

--- a/test/Test.hs
+++ b/test/Test.hs
@@ -47,6 +47,18 @@ pluginCallHostFunction = do
   res <- call p "count_vowels" "this is a test" >>= assertUnwrap
   assertEqual "count vowels output" "{\"count\":999}" res
 
+helloContext currPlugin msg = do
+  ctx <- hostContext currPlugin
+  case ctx of
+    Nothing -> assertBool "Expected host context" False
+    Just s -> putStrLn s
+  output currPlugin 0 msg
+
+pluginCallHostContext = do
+  f <- newFunction "hello_world" [ptr] [ptr] "Hello, again" helloContext
+  p <- Extism.newPlugin hostFunctionManifest [f] True >>= assertUnwrap
+  callWithHostContext p "count_vowels" "this is a test" "host context" >>= assertUnwrap
+
 pluginMultiple = do
   p <- initPlugin
   checkCallResult p
@@ -77,6 +89,7 @@ main = do
         [ t "Plugin.FunctionExists" pluginFunctionExists,
           t "Plugin.Call" pluginCall,
           t "Plugin.CallHostFunction" pluginCallHostFunction,
+          t "Plugin.CallHostContext" pluginCallHostContext,
           t "Plugin.Multiple" pluginMultiple,
           t "Plugin.Config" pluginConfig,
           t "SetLogFile" testSetLogFile,


### PR DESCRIPTION
This adds bindings for ExtismCompiledPlugin, allowing for multiple instances to be created from a single compiled plugin.

Also adds `callWithHostContext`